### PR TITLE
CERD-205 > drag drop > lock internal elements

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
     "packages": [
         "packages/*"
     ],
-    "version": "0.4.15",
+    "version": "0.4.16",
     "bootstrap": {
         "npmClientArgs": [
             "--no-package-lock"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
     "packages": [
         "packages/*"
     ],
-    "version": "0.4.16",
+    "version": "0.4.17",
     "bootstrap": {
         "npmClientArgs": [
             "--no-package-lock"

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/component-base",
-    "version": "0.4.14",
+    "version": "0.4.16",
     "description": "Assessment System Component Base Classes",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/drag-drop/demo/index.html
+++ b/packages/drag-drop/demo/index.html
@@ -65,7 +65,7 @@
             <div slot="options" id="000-3">f(x)</div>
             <div slot="options" id="000-4">dx</div>
             <div slot="options" id="000-5">
-                <img draggable="false" src="https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg" alt="Check image" style="width:22px;height:22px;border:0;">
+                <img src="https://upload.wikimedia.org/wikipedia/commons/a/ac/Approve_icon.svg" alt="Check image" style="width:22px;height:22px;border:0;">
             </div>
         </drag-container>
         <drag-container>

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -13,9 +13,9 @@
         "sass": "node-sass src/sass -r -o dist/css",
         "sass-watch": "node-sass src/sass -r -o dist/css -w",
         "watch": "npm run build; npm run sass; concurrently --names 'build,sass' -c 'bgBlue,bgMagenta' 'npm run build -- -w' 'npm run sass -- -w' 'npm-watch'",
-        "test": "lit-element-tester dist/components/{drag-drop.js,drop-container.js,drag-container.js,sortable-drop-container.js}",
+        "test": "lit-element-tester dist/components/*.js",
         "test-dev": "lit-element-tester -d",
-        "_generateDocs": "polymer analyze ./dist/components/{drag-drop.js,drop-container.js,drag-container.js,sortable-drop-container.js} > ./dist/components/analysis.json"
+        "_generateDocs": "polymer analyze ./dist/components/*.js > ./dist/components/analysis.json"
     },
     "keywords": [],
     "author": "Alexandra Djamen <alexandra.djamen@hmhco.com>",

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/drag-drop",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "description": "Assessment System Drag&Drop Component",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/drag-drop",
-    "version": "0.4.16",
+    "version": "0.4.17",
     "description": "Assessment System Drag&Drop Component",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/drag-drop/src/components/drag-container.ts
+++ b/packages/drag-drop/src/components/drag-container.ts
@@ -42,12 +42,25 @@ export class DragContainer extends ComponentBase<string> {
                 }
                 el.style.position = 'initial';
                 el.style.cursor = 'grab';
+                this.lockInternalBlockElements(el);
                 if (this.isTrash) el.remove();
                 else items.push(el.id);
             }
         );
 
         this.options = items;
+    }
+
+    /**
+     * The purpose of this function is to make sure internal block-level HTML elements
+     * are not draggable on their own.
+     *
+     * e.g. internal images
+     *
+     * @param el
+     */
+    private lockInternalBlockElements(el: HTMLElement) {
+        el.querySelectorAll('*').forEach((el: HTMLElement) => el.setAttribute('draggable', 'false'));
     }
 }
 

--- a/packages/drag-drop/src/components/drag-container.ts
+++ b/packages/drag-drop/src/components/drag-container.ts
@@ -42,7 +42,9 @@ export class DragContainer extends ComponentBase<string> {
                 }
                 el.style.position = 'initial';
                 el.style.cursor = 'grab';
-                this.lockInternalBlockElements(el);
+                // make sure internal block elements are not draggable on their own
+                el.querySelectorAll('*').forEach((el: HTMLElement) => el.setAttribute('draggable', 'false'));
+
                 if (this.isTrash) el.remove();
                 else items.push(el.id);
             }
@@ -51,17 +53,7 @@ export class DragContainer extends ComponentBase<string> {
         this.options = items;
     }
 
-    /**
-     * The purpose of this function is to make sure internal block-level HTML elements
-     * are not draggable on their own.
-     *
-     * e.g. internal images
-     *
-     * @param el
-     */
-    private lockInternalBlockElements(el: HTMLElement) {
-        el.querySelectorAll('*').forEach((el: HTMLElement) => el.setAttribute('draggable', 'false'));
-    }
+
 }
 
 customElements.define('drag-container', DragContainer);

--- a/packages/drag-drop/src/components/drag-drop.ts
+++ b/packages/drag-drop/src/components/drag-drop.ts
@@ -15,14 +15,6 @@ export class DragDrop extends ComponentBase<string[]> {
     private offsetY: number;
     private currentElement: HTMLElement;
 
-    private readonly styles: TemplateResult = html`
-    <style>
-        .option-item {
-            cursor: grab;
-        }
-    </style>
-    `;
-
     constructor() {
         super();
         if (!this.id) {
@@ -42,7 +34,6 @@ export class DragDrop extends ComponentBase<string[]> {
     protected render(): TemplateResult {
         return html`
          <link rel="stylesheet" href="/css/drag-drop.css">
-        ${this.styles}
         <slot @slotchange=${(e: Event) => this._onSlotChanged(e)}></slot>
 
         `;

--- a/packages/drag-drop/src/components/sortable-drop-container.ts
+++ b/packages/drag-drop/src/components/sortable-drop-container.ts
@@ -45,6 +45,8 @@ export class SortableDropContainer extends DropContainer {
                     el.classList.add('option-item');
                 }
                 el.style.cursor = 'grab';
+                // make sure internal block elements are not draggable on their own
+                el.querySelectorAll('*').forEach((el: HTMLElement) => el.setAttribute('draggable', 'false'));
                 items.push(el.id);
             }
         );

--- a/packages/drag-drop/src/unit/rendering.spec.ts
+++ b/packages/drag-drop/src/unit/rendering.spec.ts
@@ -43,7 +43,6 @@ export default () => {
 
             expect(element.getElement(div.id)).to.not.equal(div);
         });
-
     });
     describe(`<${dropContainerTagName}> default drop container`, (): void => {
         it('default should render as expected', (): void => {
@@ -75,7 +74,6 @@ export default () => {
 
             expect(element.getElement(div.id)).to.not.equal(div);
         });
-
     });
 
     describe(`<${dropContainerTagName}> sticky drop container`, (): void => {
@@ -133,7 +131,7 @@ export default () => {
             div.innerText = 'Option 1';
             element.appendChild(div);
         });
- 
+
         it('should  have the correct amount of initial options', async (): Promise<void> => {
             withSnippet('basic');
             const element: DragDrop = document.querySelector(basicTagName) as any;
@@ -351,6 +349,30 @@ export default () => {
                 expect(sortable.firstElementChild).to.equal(hoveredElement);
             });
         });
+
+        describe(`<${basicTagName}> sortable drag drop with HTML options`, (): void => {
+            it('should lock html elements within option items', async (): Promise<void> => {
+                withSnippet('sortable-html-options');
+                const element: DragDrop = document.querySelector(basicTagName) as any;
+                await element.updateComplete;
+                // @ts-ignore Access private member
+                const sortable: SortableDropContainer = element.dropContainers[0];
+
+                const optionsItems: HTMLElement[] = Array.from(sortable.querySelectorAll('.option-item'));
+
+                expect(optionsItems.length).to.equal(3);
+
+                optionsItems.forEach((option: HTMLElement) => {
+                    expect(option.draggable).to.be.true;
+                    const internals: HTMLElement[] = Array.from(option.querySelectorAll('*'));
+                    expect(internals.length).to.equal(3);
+                    internals.forEach((el: HTMLElement) => {
+                        expect(el.draggable).to.be.false;
+                    });
+                });
+            });
+        });
+
         describe(`<${basicTagName}> swappable drag drop`, (): void => {
             it('should be able to swap options ', async (): Promise<void> => {
                 withSnippet('swappable');

--- a/packages/drag-drop/test/runner.html
+++ b/packages/drag-drop/test/runner.html
@@ -153,6 +153,30 @@
         </drag-drop>
     </template>
 
+    <template id="sortable-html-options">
+        <drag-drop>
+            <h3>Sort These Items</h3>
+            <sortable-drop-container id="sorting">
+                <div slot="options" id="1">
+                    <figure><img src="images/img1.svg" />
+                        <figcaption>Image 1</figcaption>
+                    </figure>
+                </div>
+                <div slot="options" id="2">
+                    <figure><img src="images/img1.svg" />
+                        <figcaption>Image 1</figcaption>
+                    </figure>
+                </div>
+                <div slot="options" id="3">
+                    <figure><img src="images/img1.svg" />
+                        <figcaption>Image 1</figcaption>
+                    </figure>
+                </div>
+
+            </sortable-drop-container>
+        </drag-drop>
+    </template>
+
     <template id="nested-containers">
         <drag-drop id="animals">
             <p>Associate each animal with its name.</p>

--- a/packages/drop-down/package.json
+++ b/packages/drop-down/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/drop-down",
-    "version": "0.4.14",
+    "version": "0.4.16",
     "description": "Assessment System Drop Down Component",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/multiple-choice/package.json
+++ b/packages/multiple-choice/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/multiple-choice",
-    "version": "0.4.14",
+    "version": "0.4.16",
     "description": "Assessment System Multiple Choice Component",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/plot-graph/package.json
+++ b/packages/plot-graph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/plot-graph",
-    "version": "0.4.14",
+    "version": "0.4.16",
     "description": "Assessment System Graph Component",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/text-input",
-    "version": "0.4.14",
+    "version": "0.4.16",
     "description": "Assessment System Text Input Component",
     "main": "dist/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
When option items are defined with HTML content, the internal block-level element become draggable which causes a counter intuitive behaviour.

This PR is for making all internal HTML elements of an option non-draggable.
